### PR TITLE
More rich output format

### DIFF
--- a/make_test_files.sh
+++ b/make_test_files.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Usage:
+#     rdmd src/msgpackdump.d -s test.bin
+#
+
+# 0x000000: fixarray: 3 items                       ( 0x93 )
+# 0x000001:   positive fixint: 11                            [0x0b]
+# 0x000002:   positive fixint: 8                             [0x08]
+# 0x000003:   fixarray: 5 items                     ( 0x95 )
+# 0x000004:     uint8: 255                          ( 0xcc ) [0xff]
+# 0x000006:     positive fixint: 0                           [0x00]
+# 0x000007:     positive fixint: 7                           [0x07]
+# 0x000008:     uint8: 170                          ( 0xcc ) [0xaa]
+# 0x00000a:     positive fixint: 85                          [0x55]
+# 0x00000b: false                                   ( 0xc2 )
+# 0x00000c: true                                    ( 0xc3 )
+# 0x00000d: nil                                     ( 0xc0 )
+# 0x00000e: Invalid msgpack byte                    ( 0xc1 )
+# 0x00000f: negative fixint: -17                             [0xef]
+echo -n -e '\x93\x0b\x08\x95\xcc\xff\x00\x07\xcc\xaa\x55\xc2\xc3\xc0\xc1\xef' > test.msgpack
+
+# generates tests for fix array, array16 and array32:
+# 0x000000: fixarray: 1 items                       ( 0x91 )
+# 0x000001:   array16: 1 items                      ( 0xdc ) [0x00 0x01]
+# 0x000004:     array32: 1 items                    ( 0xdd ) [0x00 0x00 0x00 0x01]
+# 0x000009:       positive fixint: 10                        [0x0a]
+# 0x00000a: nil                                     ( 0xc0 )
+echo -n -e '\x91\xdc\x00\x01\xdd\x00\x00\x00\x01\x0a\xc0' > test.array
+
+# generates tests for fix map, map16 and map32
+# 0x000000: fixmap: 1 items                         ( 0x81 )
+# 0x000001:   positive fixint: 16                            [0x10]
+# 0x000002:   map16: 1 items                        ( 0xde ) [0x00 0x01]
+# 0x000005:     positive fixint: 32                          [0x20]
+# 0x000006:     map32: 1 items                      ( 0xdf ) [0x00 0x00 0x00 0x01]
+# 0x00000b:       positive fixint: 48                        [0x30]
+# 0x00000c:       positive fixint: 10                        [0x0a]
+# 0x00000d: nil                                     ( 0xc0 )
+echo -n -e '\x81\x10\xde\x00\x01\x20\xdf\x00\x00\x00\x01\x30\x0a\xc0' > test.map
+
+# generates tests for fixstr, str8, str16 and str32
+# 0x000000: fixstr: 'ABC'                           ( 0xa3 ) [0x41 0x42 0x43]
+# 0x000004: str8: 'DEF'                             ( 0xd9 ) [0x03 0x44 0x45 0x46]
+# 0x000009: str16: 'GHI'                            ( 0xda ) [0x00 0x03 0x47 0x48 0x49]
+# 0x00000f: str32: 'JKL'                            ( 0xdb ) [0x00 0x00 0x00 0x03 0x4a 0x4b 0x4c]
+# 0x000017: nil                                     ( 0xc0 )
+echo -n -e '\xa3\x41\x42\x43\xd9\x03\x44\x45\x46\xda\x00\x03\x47\x48\x49\xdb\x00\x00\x00\x03\x4a\x4b\x4c\xc0' > test.str
+
+# generates tests for fixext1, fixext2, fixext4, fixext8
+# 0x000000: fixext1: 1 + 1 items                    ( 0xd4 ) [0x01 0x0e]
+# 0x000003: fixext2: 2 + 2 items                    ( 0xd5 ) [0x02 0x01 0x02]
+# 0x000007: fixext4: 4 + 4 items                    ( 0xd6 ) [0x04 0x03 0x04 0x05 0x06]
+# 0x00000d: fixext8: 8 + 8 items                    ( 0xd7 ) [0x08 0x07 0x08 0x09 0x0a 0x0b 0x0c 0x0d 0x0e]
+# 0x000017: nil                                     ( 0xc0 )
+echo -n -e '\xd4\x01\x0e\xd5\x02\x01\x02\xd6\x04\x03\x04\x05\x06\xd7\x08\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\xc0' > test.fixext
+
+# generates tests for fixext16
+# 0x000000: fixext16: 16 + 16 items                 ( 0xd8 ) [0x10 0x00 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x08 0x09 0x0a 0x0b 0x0c 0x0d 0x0e 0x0f]
+# 0x000012: nil                                     ( 0xc0 )
+echo -n -e '\xd8\x10\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\xc0' > test.fixext16
+
+# generates tests for ext8, ext16, ext32
+# 0x000000: ext8: 8 + 1 items                       ( 0xc7 ) [0x01 0x08 0x01]
+# 0x000004: ext16: 16 + 1 items                     ( 0xc8 ) [0x00 0x01 0x10 0x02]
+# 0x000009: ext32: 32 + 1 items                     ( 0xc9 ) [0x00 0x00 0x00 0x01 0x20 0x03]
+# 0x000010: nil                                     ( 0xc0 )
+echo -n -e '\xc7\x01\x08\x01\xc8\x00\x01\x10\x02\xc9\x00\x00\x00\x01\x20\x03\xc0' > test.ext
+
+# generates tests for bin8
+# 0x000000: bin8:                                   ( 0xc4 ) [0x00]
+# 0x000002: bin8: A                                 ( 0xc4 ) [0x01 0x41]
+# 0x000005: bin8: BC                                ( 0xc4 ) [0x02 0x42 0x43]
+# 0x000009: bin8: DEF                               ( 0xc4 ) [0x03 0x44 0x45 0x46]
+# 0x00000e: nil                                     ( 0xc0 )
+echo -n -e '\xc4\x00\xc4\x01\x41\xc4\x02\x42\x43\xc4\x03\x44\x45\x46\xc0' > test.bin8
+
+# generates tests for bin16, bin32
+# 0x000000: bin16: A                                ( 0xc5 ) [0x00 0x01 0x41]
+# 0x000004: bin32: B                                ( 0xc6 ) [0x00 0x00 0x00 0x01 0x42]
+# 0x00000a: nil                                     ( 0xc0 )
+echo -n -e '\xc5\x00\x01\x41\xc6\x00\x00\x00\x01\x42\xc0' > test.bin
+
+# generates tests for float32, float64
+# 0x000000: float32: 1.23457e+08                    ( 0xca ) [0x4c 0xeb 0x79 0xa3]
+# 0x000005: float64: 1.23457e+08                    ( 0xcb ) [0x41 0x9d 0x6f 0x34 0x54 0x00 0x00 0x00]
+# 0x00000e: nil                                     ( 0xc0 )
+echo -n -e '\xca\x4c\xeb\x79\xa3\xcb\x41\x9d\x6f\x34\x54\x00\x00\x00\xc0' > test.float
+
+# generates tests for uint8, uint16, uint32, uint64
+# 0x000000: uint8: 255                              ( 0xcc ) [0xff]
+# 0x000002: uint16: 257                             ( 0xcd ) [0x01 0x01]
+# 0x000005: uint32: 16777216                        ( 0xce ) [0x01 0x00 0x00 0x00]
+# 0x00000a: uint64: 72057594037927936               ( 0xcf ) [0x01 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+# 0x000013: nil                                     ( 0xc0 )
+echo -n -e '\xcc\xff\xcd\x01\x01\xce\x01\x00\x00\x00\xcf\x01\x00\x00\x00\x00\x00\x00\x00\xc0' > test.uint
+
+# generates tests for int8, int16, int32, int64
+# 0x000000: int8: 255                               ( 0xd0 ) [0xff]
+# 0x000002: int16: 257                              ( 0xd1 ) [0x01 0x01]
+# 0x000005: int32: 16777216                         ( 0xd2 ) [0x01 0x00 0x00 0x00]
+# 0x00000a: int64: 72057594037927936                ( 0xd3 ) [0x01 0x00 0x00 0x00 0x00 0x00 0x00 0x00]
+# 0x000013: nil                                     ( 0xc0 )
+echo -n -e '\xd0\xff\xd1\x01\x01\xd2\x01\x00\x00\x00\xd3\x01\x00\x00\x00\x00\x00\x00\x00\xc0' > test.int

--- a/src/msgpackdump.d
+++ b/src/msgpackdump.d
@@ -9,6 +9,8 @@ import std.stdio;
 import std.exception;
 import core.bitop : bswap;
 
+enum hasNoUnsignedSwap = __VERSION__ < 2088;
+
 private ushort bswap(ushort u)
 {
 	version (LittleEndian)
@@ -42,66 +44,71 @@ private ushort bswap(ushort u)
 	else return u;
 }
 
-private ulong bswap(ulong u)
+version(hasNoUnsignedSwap)
 {
-	version (LittleEndian)
+	private ulong bswap(ulong u)
 	{
-		version (D_InlineAsm_X86_64)
+		version (LittleEndian)
 		{
-			asm
+			version (D_InlineAsm_X86_64)
 			{
-				naked;
-				mov RAX, RDI;
-				bswap RAX;
-				ret;
+				asm
+				{
+					naked;
+					mov RAX, RDI;
+					bswap RAX;
+					ret;
+				}
 			}
-		}
-		else
-		{
-			union UlongBytes
+			else
 			{
-				ulong u;
-				ubyte[8] b;
-			}
+				union UlongBytes
+				{
+					ulong u;
+					ubyte[8] b;
+				}
 
-			UlongBytes src;
-			src.u = u;
-			UlongBytes dst;
-			dst.b[0] = src.b[7];
-			dst.b[1] = src.b[6];
-			dst.b[2] = src.b[5];
-			dst.b[3] = src.b[4];
-			dst.b[4] = src.b[3];
-			dst.b[5] = src.b[2];
-			dst.b[6] = src.b[1];
-			dst.b[7] = src.b[0];
-			return dst.u;
+				UlongBytes src;
+				src.u = u;
+				UlongBytes dst;
+				dst.b[0] = src.b[7];
+				dst.b[1] = src.b[6];
+				dst.b[2] = src.b[5];
+				dst.b[3] = src.b[4];
+				dst.b[4] = src.b[3];
+				dst.b[5] = src.b[2];
+				dst.b[6] = src.b[1];
+				dst.b[7] = src.b[0];
+				return dst.u;
+			}
 		}
+		else return u;
 	}
-	else return u;
 }
 
-private T read16(T)(ref size_t index, const ubyte[] bytes) if (T.sizeof == 2)
+private T read(T)(size_t index, const ubyte[] bytes) if (T.sizeof == 1)
+{
+	return cast(T) bytes[index];
+}
+
+private T read(T)(size_t index, const ubyte[] bytes) if (T.sizeof == 2)
 {
 	auto buf = bswap(*(cast(ushort*) (bytes.ptr + index)));
-        T r = *(cast(T*) &buf);
-        index += 2;
+	T r = *(cast(T*) &buf);
 	return r;
 }
 
-private T read32(T)(ref size_t index, const ubyte[] bytes) if (T.sizeof == 4)
+private T read(T)(size_t index, const ubyte[] bytes) if (T.sizeof == 4)
 {
 	auto buf = bswap(*(cast(uint*) (bytes.ptr + index)));
-        T r = *(cast(T*) &buf);
-        index += 4;
+	T r = *(cast(T*) &buf);
 	return r;
 }
 
-private T read64(T)(ref size_t index, const ubyte[] bytes) if (T.sizeof == 8)
+private T read(T)(size_t index, const ubyte[] bytes) if (T.sizeof == 8)
 {
 	auto buf = bswap(*(cast(ulong*) (bytes.ptr + index)));
-        T r = *(cast(T*) &buf);
-        index += 8;
+	T r = *(cast(T*) &buf);
 	return r;
 }
 
@@ -127,13 +134,216 @@ void main(string[] args)
 	ubyte[] bytes = new ubyte[](f.size);
 	f.rawRead(bytes);
 	size_t[] itemCounts;
+	size_t left_padding;
+	string indent = "  ";
+	// Current line
+	enum TextWidth = 4096;
+	char[TextWidth] line;
+	// Current pos in the current line
+	size_t pos;
+
+	void formattedPrintToLine(Char, Args...)(in Char[] fmt, Args args)
+	{
+		import core.exception : RangeError;
+
+		import std.format : sformat;
+		char[] formatted;
+		try
+		{
+			formatted = sformat(line[pos..TextWidth], fmt, args);
+		}
+		catch(RangeError re)
+		{
+			import std.algorithm : copy;
+			import std.format : format;
+			// Buffer is insufficent to output,
+			// allocate appropriate length line on the heap
+			// but copy there only data chunk that is placeable
+			// to the buffer
+			formatted = cast(char[])format(fmt, args)[0..TextWidth - pos];
+			copy(formatted, line[pos..TextWidth]);
+		}
+		pos += formatted.length;
+		assert (pos < TextWidth);
+	}
+
+	/// prints msgpack format
+	void printFormat(Char, Args...)(in Char[] fmt, Args args)
+	{
+		import std.range : repeat, join;
+		import std.algorithm : min, max;
+
+		formattedPrintToLine("0x%06x: ", index);
+
+		foreach (_; 0 .. left_padding)
+			formattedPrintToLine("  ");
+
+		formattedPrintToLine(fmt, args);
+		formattedPrintToLine(" ".repeat(max(0, 50 - cast(int)pos)).join);
+		formattedPrintToLine("( 0x%02x )", bytes[index]);
+		index++;
+	}
+
+	/// prints data in msgpack format
+	void printData(Char, Args...)(in Char[] fmt, Args args)
+	{
+		import std.range : repeat, join;
+		import std.algorithm : min, max;
+
+		formattedPrintToLine("0x%06x: ", index);
+
+		foreach (_; 0 .. left_padding)
+			formattedPrintToLine("  ");
+
+		formattedPrintToLine(fmt, args);
+
+		formattedPrintToLine(" ".repeat(max(0, 50 - cast(int)pos)).join);
+		formattedPrintToLine("         [%(0x%02x %)]", bytes[index..index+1]);
+		index++;
+	}
+
+	void printFixStr(Char, Args...)(ubyte format, ubyte[] data, in Char[] fmt, Args args)
+	{
+		import std.range : repeat, join;
+		import std.algorithm : min, max;
+
+		formattedPrintToLine("0x%06x: ", index);
+
+		foreach (_; 0 .. left_padding)
+		{
+			formattedPrintToLine("  ");
+		}
+
+		formattedPrintToLine(fmt, args);
+
+		formattedPrintToLine(" ".repeat(max(0, 50 - cast(int)pos)).join);
+
+		formattedPrintToLine("( 0x%02x ) ", format);
+		formattedPrintToLine("[%(0x%02x %)]", data);
+	}
+
+	void printBinOrStr(T)(string format_name)
+	{
+		import std.range : repeat, join;
+		import std.algorithm : min, max;
+
+		formattedPrintToLine("0x%06x: ", index);
+
+		foreach (_; 0 .. left_padding)
+			formattedPrintToLine("  ");
+
+		size_t l = read!T(index+1, bytes);
+		auto data = bytes[index+1..index+l+1+T.sizeof];
+
+		formattedPrintToLine(format_name ~ ": '%s'", assumeStrings ? cast(char[]) data[T.sizeof..$] : "not shown");
+		formattedPrintToLine(" ".repeat(max(0, 50 - cast(int)pos)).join);
+		formattedPrintToLine("( 0x%02x ) ", bytes[index]);
+		formattedPrintToLine("[%(0x%02x %)]", data);
+
+		index += l + 1 + T.sizeof;
+	}
+
+	void printScalar(T)(string format_name)
+	{
+		import std.range : repeat, join;
+		import std.algorithm : min, max;
+
+		formattedPrintToLine("0x%06x: ", index);
+
+		foreach (_; 0 .. left_padding)
+			formattedPrintToLine("  ");
+
+		size_t l = 1 + T.sizeof;
+		auto data = bytes[index+1..index+l];
+
+		formattedPrintToLine(format_name ~ ": %s", read!T(0, data));
+		formattedPrintToLine(" ".repeat(max(0, 50 - cast(int)pos)).join);
+		formattedPrintToLine("( 0x%02x ) ", bytes[index]);
+		formattedPrintToLine("[%(0x%02x %)]", data);
+
+		index += l;
+	}
+
+	size_t printArrayAndMap(T)(string format_name)
+	{
+		import std.range : repeat, join;
+		import std.algorithm : min, max;
+
+		formattedPrintToLine("0x%06x: ", index);
+
+		foreach (_; 0 .. left_padding)
+			formattedPrintToLine("  ");
+
+		size_t l = read!T(index+1, bytes);
+		auto data = bytes[index+1..index+T.sizeof+1];
+
+		formattedPrintToLine(format_name ~ ": %s items", l);
+		formattedPrintToLine(" ".repeat(max(0, 50 - cast(int)pos)).join);
+		formattedPrintToLine("( 0x%02x ) ", bytes[index]);
+		formattedPrintToLine("[%(0x%02x %)]", data);
+
+		index += T.sizeof + 1;
+		itemCounts ~= l;
+
+		return l;
+	}
+
+	size_t printExt(T)(string format_name)
+	{
+		import std.range : repeat, join;
+		import std.algorithm : min, max;
+
+		formattedPrintToLine("0x%06x: ", index);
+
+		foreach (_; 0 .. left_padding)
+			formattedPrintToLine("  ");
+
+		size_t l = read!T(index+1, bytes);
+		auto data = bytes[index+1..index+1+T.sizeof+1+l];
+
+		const type = bytes[index+1+T.sizeof];
+		formattedPrintToLine(format_name ~ ": %s + %s items", type, l);
+		formattedPrintToLine(" ".repeat(max(0, 50 - cast(int)pos)).join);
+		formattedPrintToLine("( 0x%02x ) ", bytes[index]);
+		formattedPrintToLine("[%(0x%02x %)]", data);
+
+		index += T.sizeof + 2 + l;
+
+		return l;
+	}
+
+	size_t printFixExt(size_t l)(string format_name)
+	{
+		import std.range : repeat, join;
+		import std.algorithm : min, max;
+
+		formattedPrintToLine("0x%06x: ", index);
+
+		foreach (_; 0 .. left_padding)
+			formattedPrintToLine("  ");
+
+		auto data = bytes[index+1..index+1+1+l];
+
+		const type = bytes[index+1];
+		formattedPrintToLine(format_name ~ ": %s + %s items", type, l);
+		formattedPrintToLine(" ".repeat(max(0, 50 - cast(int)pos)).join);
+		formattedPrintToLine("( 0x%02x ) ", bytes[index]);
+		formattedPrintToLine("[%(0x%02x %)]", data);
+
+		index += 2 + l;
+
+		return l;
+	}
 
 	while (index < bytes.length)
 	{
+		left_padding = 0;
 		if (itemCounts.length)
 		{
 			foreach (_; 0 .. itemCounts.length)
-				write("  ");
+			{
+				left_padding += 1;
+			}
 			if (itemCounts[$ - 1] > 0)
 				itemCounts[$ - 1]--;
 
@@ -141,215 +351,135 @@ void main(string[] args)
 		switch (bytes[index])
 		{
 		case 0x00: .. case 0x7f: // positive fixint  0xxxxxxx
-			writeln("positive fixint: ", bytes[index]);
-			index++;
+			printData("positive fixint: %d", bytes[index]);
 			break;
 		case 0x80: .. case 0x8f: // fixmap  1000xxxx
 			int l = bytes[index] & 0b1111;
-			itemCounts ~= l;
-			writeln("fixmap: ", l, " items");
-			index++;
+			itemCounts ~= l*2;
+			printFormat("fixmap: %d items", l);
 			break;
 		case 0x90: .. case 0x9f: // fixarray  1001xxxx
 			int l = bytes[index] & 0b1111;
 			itemCounts ~= l;
-			writeln("fixarray: ", l, " items");
-			index++;
+			printFormat("fixarray: %d items", l);
 			break;
 		case 0xa0: .. case 0xbf: // fixstr  101xxxxx
 			immutable size_t l = (cast(size_t) bytes[index]) & 0b11111;
-			index++;
-			writeln("fixstr: ", cast(string) bytes[index .. index + l]);
-			index += l;
+			printFixStr(bytes[index], bytes[index+1..index+l+1], "fixstr: '%s'", cast(char[])bytes[index+1 .. index+l+1]);
+			index += l+1;
 			break;
 		case 0xc0: // nil  11000000
-			writeln("nil");
-			index++;
+			printFormat("nil");
 			break;
 		case 0xc1: // (never used)  11000001
-			writeln("Invalid msgpack byte");
-			index++;
+			printFormat("Invalid msgpack byte");
 			break;
 		case 0xc2: // false  11000010
-			writeln("false");
-			index++;
+			printFormat("false");
 			break;
 		case 0xc3: // true  11000011
-			writeln("true");
-			index++;
+			printFormat("true");
 			break;
 		case 0xc4: // bin 8  11000100
-			index++;
-			if (assumeStrings)
-			{
-				size_t l = bytes[index++];
-				writeln("bin8: ", cast(char[])bytes[index .. index + l]);
-				index += l;
-			} else {
-				index += bytes[index] + 1;
-				writeln("bin8: not shown");
-			}
+			printBinOrStr!ubyte("bin8");
 			break;
 		case 0xc5: // bin 16  11000101
-			index++;
-			if (assumeStrings)
-			{
-				size_t l = read16!(ushort)(index, bytes);
-				writeln("bin16: ", cast(char[])bytes[index .. index + l]);
-				index += l;
-			} else {
-				size_t l = read16!(ushort)(index, bytes);
-				index += l;
-				writeln("bin16: not shown");
-			}
+			printBinOrStr!ushort("bin16");
 			break;
 		case 0xc6: // bin 32  11000110
-			index++;
-			if (assumeStrings)
-			{
-				size_t l = read32!(uint)(index, bytes);
-				writeln("bin32: ", cast(char[])bytes[index .. index + l]);
-				index += l;
-			} else {
-				size_t l = read32!(uint)(index, bytes);
-				index += l;
-				writeln("bin32: not shown");
-			}
+			printBinOrStr!uint("bin32");
 			break;
 		case 0xc7: // ext 8  11000111
-			index++;
-			index += bytes[index] + 2;
-			writeln("ext8: not shown");
+			printExt!ubyte("ext8");
 			break;
 		case 0xc8: // ext 16  11001000
-			index++;
-			size_t l = read16!(ushort)(index, bytes);
-			index += l + 1;
-			writeln("ext16: not shown");
+			printExt!ushort("ext16");
 			break;
 		case 0xc9: // ext 32  11001001
-			index++;
-			size_t l = read32!(uint)(index, bytes);
-			index += l + 1;
-			writeln("ext32: not shown");
+			printExt!uint("ext32");
 			break;
 		case 0xca: // float 32  11001010
-			index++;
-			writeln("float32: ", read32!float(index, bytes));
+			printScalar!float("float32");
 			break;
 		case 0xcb: // float 64  11001011
-			index++;
-			writeln("float64: ", read64!double(index, bytes));
+			printScalar!double("float64");
 			break;
 		case 0xcc: // uint 8  11001100
-			writeln("uint8: ", bytes[index + 1]);
-			index += 2;
+			printScalar!ubyte("uint8");
 			break;
-		case 0xcd: // uint 16  11001101
-			index++;
-			writeln("uint16: ", read16!ushort(index, bytes));
+		case 0xcd:
+			printScalar!ushort("uint16");
 			break;
 		case 0xce: // uint 32  11001110
-			index++;
-			writeln("uint32: ", read32!uint(index, bytes));
+			printScalar!uint("uint32");
 			break;
 		case 0xcf: // uint 64  11001111
-		        index++;
-			writeln("uint64: ", read64!ulong(index, bytes));
+			printScalar!ulong("uint64");
 			break;
 		case 0xd0: // int 8  11010000
-			writeln("int8: ", cast(byte) bytes[index + 1]);
-			index += 2;
+			printScalar!ubyte("int8");
 			break;
 		case 0xd1: // int 16  11010001
-			index++;
-			writeln("int16: ", read16!(short)(index, bytes));
+			printScalar!ushort("int16");
 			break;
 		case 0xd2: // int 32  11010010
-			index++;
-			writeln("int32: ", read32!int(index, bytes));
+			printScalar!uint("int32");
 			break;
 		case 0xd3: // int 64  11010011
-			index++;
-			writeln("int64: ", read64!long(index, bytes));
+			printScalar!ulong("int64");
 			break;
 		case 0xd4: // fixext 1  11010100
-			index += 3;
-			writeln("fixext1: not shown");
+			printFixExt!1("fixext1");
 			break;
 		case 0xd5: // fixext 2  11010101
-			index += 4;
-			writeln("fixext2: not shown");
+			printFixExt!2("fixext2");
 			break;
 		case 0xd6: // fixext 4  11010110
-			index += 6;
-			writeln("fixext4: not shown");
+			printFixExt!4("fixext4");
 			break;
 		case 0xd7: // fixext 8  11010111
-			index += 20;
-			writeln("fixext8: not shown");
+			printFixExt!8("fixext8");
 			break;
 		case 0xd8: // fixext 16  11011000
-			index += 18;
-			writeln("fixext16: not shown");
+			printFixExt!16("fixext16");
 			break;
 		case 0xd9: // str 8  11011001
-			index++;
-			size_t l = bytes[index];
-			index++;
-			writeln("str8: ", cast(char[]) bytes[index .. index + l]);
-			index += l;
+			printBinOrStr!ubyte("str8");
 			break;
 		case 0xda: // str 16  11011010
-			index++;
-			size_t l = read16!ushort(index, bytes);
-			writeln("str16: ", cast(char[]) bytes[index .. index + l]);
-			index += l;
+			printBinOrStr!ushort("str16");
 			break;
 		case 0xdb: // str 32  11011011
-			index++;
-			size_t l = read32!(uint)(index, bytes);
-			writeln("str32: ", cast(char[]) bytes[index .. index + l]);
-			index += l;
+			printBinOrStr!uint("str32");
 			break;
 		case 0xdc: // array 16  11011100
-			index++;
-			size_t l = read16!ushort(index, bytes);
-			itemCounts ~= l;
-			writeln("array16: ", l, " items");
-			index += l;
+			printArrayAndMap!ushort("array16");
 			break;
 		case 0xdd: // array 32  11011101
-			index++;
-			size_t l = read32!uint(index, bytes);
-			itemCounts ~= l;
-			writeln("array32: ", l, " items");
-			index += l;
+			printArrayAndMap!uint("array32");
 			break;
 		case 0xde: // map 16  11011110
-			index++;
-			size_t l = read16!ushort(index, bytes);
-			itemCounts ~= l;
-			writeln("map16: ", l, " items");
-			index += l;
+			// maps has double count of elements so
+			// add them once again
+			auto l = printArrayAndMap!ushort("map16");
+			itemCounts[$-1] += l;
 			break;
 		case 0xdf: // map 32  11011111
-			index++;
-			size_t l = read32!uint(index, bytes);
-			itemCounts ~= l;
-			writeln("map32: ", l, " items");
-			index += l;
+			// maps has double count of elements so
+			// add them once again
+			auto l = printArrayAndMap!uint("map32");
+			itemCounts[$-1] += l;
 			break;
-		case 0xe0 - 0xff: // negative fixint  111xxxxx
-			writeln("negative fixint: ", -(cast(byte) bytes[index]));
-			index++;
+		case 0xe0: .. case 0xff: // negative fixint  111xxxxx
+			printData("negative fixint: %d", cast(byte) bytes[index]);
 			break;
 		default:
-			writeln("default");
-			index++;
+			printData("Unknown value: %d", bytes[index]);
 			break;
 		}
 		while (itemCounts.length && itemCounts[$ - 1] == 0)
 			itemCounts = itemCounts[0 .. $ - 1];
+		writeln(line[0..pos]);
+		pos = 0;
 	}
 }


### PR DESCRIPTION
Trying to merge old changes to upstream. Major changes are additional output of data address and data in hex format. Old output is preserved.
Output before:
```
fixarray: 3 items
  positive fixint: 11
  positive fixint: 8
  fixarray: 5 items
    uint8: 255
    positive fixint: 0
    positive fixint: 7
    uint8: 170
    positive fixint: 85
```
Output after:
```
0x000000: fixarray: 3 items                       ( 0x93 )
0x000001:   positive fixint: 11                            [0x0b]
0x000002:   positive fixint: 8                             [0x08]
0x000003:   fixarray: 5 items                     ( 0x95 )
0x000004:     uint8: 255                          ( 0xcc ) [0xff]
0x000006:     positive fixint: 0                           [0x00]
0x000007:     positive fixint: 7                           [0x07]
0x000008:     uint8: 170                          ( 0xcc ) [0xaa]
0x00000a:     positive fixint: 85                          [0x55]
```
Metadata are in braces, data are in brackets.